### PR TITLE
Fix 4/6 problems in JCache1.1.0 TCK 

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -453,7 +453,7 @@
                                         <artifactItem>
                                             <groupId>javax.cache</groupId>
                                             <artifactId>app-domain</artifactId>
-                                            <version>${javax.cache.tck.version}</version>
+                                            <version>${javax.cache.version}</version>
                                             <outputDirectory>${domain-lib-dir}</outputDirectory>
                                             <destFileName>${domain-jar}</destFileName>
                                         </artifactItem>

--- a/modules/core/src/main/java/org/apache/ignite/cache/CacheManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/CacheManager.java
@@ -221,14 +221,6 @@ public class CacheManager implements javax.cache.CacheManager {
         try {
             IgniteCache<K, V> cache = getCache0(cacheName);
 
-            if (cache != null) {
-                if(cache.getConfiguration(Configuration.class).getKeyType() != Object.class)
-                    throw new IllegalArgumentException();
-
-                if(cache.getConfiguration(Configuration.class).getValueType() != Object.class)
-                    throw new IllegalArgumentException();
-            }
-
             return cache;
         }
         finally {
@@ -258,8 +250,7 @@ public class CacheManager implements javax.cache.CacheManager {
 
         try {
             if (kernalGateway.getState() != GridKernalState.STARTED)
-                return Collections.emptySet(); // javadoc of #getCacheNames() says that IllegalStateException should be
-                                               // thrown but CacheManagerTest.close_cachesEmpty() require empty collection.
+                throw new IllegalStateException();
 
             Collection<String> res = new ArrayList<>();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheClusterMetricsMXBeanImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheClusterMetricsMXBeanImpl.java
@@ -251,7 +251,7 @@ class CacheClusterMetricsMXBeanImpl implements CacheMetricsMXBean {
 
     /** {@inheritDoc} */
     @Override public void clear() {
-        throw new UnsupportedOperationException("Cluster metrics can't be cleared. Use local metrics clear instead.");
+        cache.metrics.clear();
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -1781,8 +1781,7 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
                 cctx.statisticsEnabled() &&
                 needVal) {
                 // PutIfAbsent methods must not update hit/miss statistics.
-                if (op != GridCacheOperation.UPDATE || F.isEmpty(filter) || !cctx.putIfAbsentFilter(filter))
-                    cctx.cache().metrics0().onRead(oldVal != null);
+                cctx.cache().metrics0().onRead(oldVal != null);
             }
 
             switch (updateRes.outcome()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -1779,10 +1779,8 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
             if (metrics &&
                 updateRes.outcome().updateReadMetrics() &&
                 cctx.statisticsEnabled() &&
-                needVal) {
-                // PutIfAbsent methods must not update hit/miss statistics.
+                needVal)
                 cctx.cache().metrics0().onRead(oldVal != null);
-            }
 
             switch (updateRes.outcome()) {
                 case VERSION_CHECK_FAILED: {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,7 +78,7 @@
         <jackson2.version>2.6.5</jackson2.version>
         <javassist.version>3.20.0-GA</javassist.version>
         <javax.cache.bundle.version>1.0.0_1</javax.cache.bundle.version>
-        <javax.cache.tck.version>1.0.1</javax.cache.tck.version>
+        <javax.cache.tck.version>1.1.0</javax.cache.tck.version>
         <javax.cache.version>1.0.0</javax.cache.version>
         <jetbrains.annotations.version>13.0</jetbrains.annotations.version>
         <jetty.version>9.2.11.v20150529</jetty.version>


### PR DESCRIPTION
I have tested our current master with JCache TCK 1.1.0 fix some problems, and prepared following summary:
# Summary

Total failed tests: **104**.
A number of different problems: 6.
Problems which **will** break TCK 1.0.1 after fix: **2** (have tested).

## Problem 1 (not done): Problems with `Closeable` objects from `Factory`.

According to spec `Cache.close()` should clean up all `Closeable` objects created by following factories: `CacheLoader`, `CacheWriter`, `CacheEntryListener`, `ExpiryPolicy`.
And in TCK 1.0.1 there are no such tests. But in TCK 1.1.0 there are checks for it. And Ignite fails it because hasn't such functionality.

- Link: https://github.com/jsr107/jsr107tck/issues/100
- Failed tests: **98**.
- Changing in RI for example: https://github.com/jsr107/RI/pull/51/files
- Break TCK for 1.0.1: _Should not_.
- Fix trivial: **No**. Required to choose a way for storing `Closeable` objects created by `Factory` which passed into `IgniteCache`, like `evictPlcFactory`, `expiryPolicyFactory`, `storeFactory`. I believe more experienced contributors will want to design it.

List of test classes in TCK:

1. `CacheListenerTest`
2. `CacheExpiryTest`
3. `CacheLoaderTest`
4. `CacheLoaderWithExpiryTest`
5. `CacheLoaderWithoutReadThroughTest`
6. `CacheLoaderWriterTest`
7. `CacheWriterTest`

## Problem 2 (done): `CacheManagerTest.close_cachesEmpty`
Method `CacheManager.getCacheNames()` should throw `IllegalStateException` in case when `CacheManager` is closed. But in TCK 1.0.1 test `CacheManagerTest.close_cachesEmpty` expect empty list, which was incorrect according to spec.
In TCK 1.1.0 test is fixed.
It was known problem, please see comments in `CacheManager#getCacheNames()` on current master.
But we can't make this test pass in both versions of TCK.

Link: https://github.com/jsr107/jsr107tck/issues/87
Failed tests: **1**.
Changing in RI for example: https://github.com/jsr107/RI/pull/49/files
Break TCK for 1.0.1: **Yes. New test expects `Exception`, but old test expects empty list.**
Fix trivial: Yes. See `CacheManager#getCacheNames()`.

## Problem 3 (done): `CacheMBStatisticsBeanTest.testClear`
`CacheStatisticsMXBean.clear()` was never tested. Now it is.

Link: https://github.com/jsr107/jsr107tck/issues/101
Failed tests: **1**.
Changing in RI for example: ----
Break  TCK for 1.0.1: No.
Fix trivial: Yes. See `CacheClusterMetricsMXBeanImpl#clear()`

## Problem 4 (not done): `CacheEntryEvent.getOldValue` should be available

Link:

- https://github.com/jsr107/jsr107tck/pull/133
- https://github.com/jsr107/jsr107spec/issues/391

Failed tests: **2**.
List of tests:

- `CacheListenerTest.testFilteredListener`
- `CacheListenerTest.testCacheEntryListener`

Changing in RI for example: ----
Break  TCK for 1.0.1: _Should not_.
Fix trivial:  **No**. See `CacheContinuousQueryManager#existingEntries`. Need somehow restore old value from entry event. Required to redesign continuous query a bit. I believe more experienced contributors will want to design it.

## Problem 5 (done): CacheManagerTest.getUnsafeTypedCacheRequest

Link: 

- https://github.com/jsr107/jsr107spec/issues/340
- https://github.com/jsr107/jsr107tck/issues/83

Failed tests: **1**.
Changing in RI for example: ----
Break  TCK for 1.0.1: No.
Fix trivial: Yes. See `CacheManager#getCache()`

## Problem 6 (done): `CacheMBStatisticsBeanTest.testPutIfAbsent` -- `putIfAbsent` doesn't update hit/miss statistics.

Link: https://github.com/jsr107/jsr107tck/issues/63
Failed tests: **1**.
Changing in RI for example: ----
Break  TCK for 1.0.1: **Yes. New test expects 1, but old test expects 0 in the same situation.**
Fix trivial: Yes. See `GridCacheMapEntry.innerUpdate()`
